### PR TITLE
Open google com in termux

### DIFF
--- a/open_google.py
+++ b/open_google.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+Simple Python script to open Google in the default browser.
+Designed for use in Termux on Android.
+"""
+
+import webbrowser
+import sys
+
+def open_google():
+    """Open Google in the default browser."""
+    url = "https://www.google.com"
+    
+    try:
+        print(f"Opening {url} in your default browser...")
+        webbrowser.open(url)
+        print("Success! Google should now be opening in your browser.")
+    except Exception as e:
+        print(f"Error opening browser: {e}")
+        print("Make sure you have a browser installed on your device.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    open_google()


### PR DESCRIPTION
Add `open_google.py` script to open www.google.com in the default browser, fulfilling the user's request for a Termux-compatible solution.

---
<a href="https://cursor.com/background-agent?bcId=bc-e057dd47-8a52-4a9f-9cd6-24a23e557104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e057dd47-8a52-4a9f-9cd6-24a23e557104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

